### PR TITLE
Fix environment key error

### DIFF
--- a/app/views/skylight/docs/chapters/_60-environments.md
+++ b/app/views/skylight/docs/chapters/_60-environments.md
@@ -119,7 +119,7 @@ For example, in Sinatra:
 ```ruby
 configure :production, :staging do
   require "skylight/sinatra"
-  Skylight.start!(file: PATH_TO_CONFIG, env: ENVIRONMENT)
+  Skylight.start!(file: PATH_TO_CONFIG, environment: ENVIRONMENT)
 end
 ```
 

--- a/app/views/skylight/docs/chapters/_60-environments.md
+++ b/app/views/skylight/docs/chapters/_60-environments.md
@@ -156,7 +156,7 @@ For example, in Sinatra:
 ```ruby
 configure :production, :staging do
   require "skylight/sinatra"
-  Skylight.start!(env: ENVIRONMENT)
+  Skylight.start!(environment: ENVIRONMENT)
 end
 ```
 


### PR DESCRIPTION
Is there an error in the docs? They say to use the `env` key, while in the code it's `environment`

The code:
https://github.com/skylightio/skylight-ruby/blob/9072ec33878ac6d6b9987c5a5a527e8460e35c2c/lib/skylight/config.rb#L280


https://www.skylight.io/support/environments#2-require-and-start-the-skylight-agent-in-each-of-your-desired-environments
![Screenshot from 2020-10-10 21-03-03](https://user-images.githubusercontent.com/2538374/95660911-07b24900-0b3c-11eb-9774-8ca8b64653a1.png)
